### PR TITLE
moves container_name to image_name, removes need for script_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ if os.getenv(check_name, None) is None:
     import dockrice.argparse as argparse
 
     parser_kwargs = {
-        "script_name": __file__,
         "container_name": "python",
         "docker_kwargs": {"environment": {check_name: ""}},
     }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ if os.getenv(check_name, None) is None:
     import dockrice.argparse as argparse
 
     parser_kwargs = {
-        "container_name": "python",
+        "image": "python",
         "docker_kwargs": {"environment": {check_name: ""}},
     }
 else:

--- a/dockrice/argparse.py
+++ b/dockrice/argparse.py
@@ -145,7 +145,7 @@ class DockerActionFactory:
 
         if self.image_name is None:
             raise ValueError(
-                "'image_name' is not defined. " "This is required for a docker to run"
+                "'image_name' is not defined. This is required for a docker to run."
             )
 
         # create docker client

--- a/examples/self_in_docker.py
+++ b/examples/self_in_docker.py
@@ -9,8 +9,6 @@ if os.getenv(check_name, None) is None:
     import dockrice.argparse as argparse
 
     parser_kwargs = {
-        "script_name": __file__,
-        "container_name": "python",
         "docker_kwargs": {"environment": {check_name: ""}},
     }
 else:

--- a/examples/self_in_docker.py
+++ b/examples/self_in_docker.py
@@ -9,6 +9,7 @@ if os.getenv(check_name, None) is None:
     import dockrice.argparse as argparse
 
     parser_kwargs = {
+        "image": "python",
         "docker_kwargs": {"environment": {check_name: ""}},
     }
 else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dockrice
-version = 0.0.1
+version = 0.0.2
 
 [options]
 packages = dockrice


### PR DESCRIPTION
In the future I would like to use `image_name` instead of `container_name` as it is not a container, but an image name and thus more accurate. There will be a deprecation period.

This will also remove the need for providing a script_name, it can be found automatically now.

Will move up the version number by one.